### PR TITLE
Fall back to other endpoints for metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "deposit-box"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "askama",
  "askama_rocket",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deposit-box"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 
 [features]

--- a/src/impl/config.rs
+++ b/src/impl/config.rs
@@ -106,7 +106,7 @@ impl Config {
             products_yml_path: ProductsYmlPath::get_checked().ok(),
         };
 
-        if !Self::check_env(&slf.endpoints()) {
+        if !Self::check_env(slf.endpoints()) {
             return Err(());
         }
 
@@ -228,7 +228,7 @@ impl Config {
     }
 
     pub fn endpoints(&self) -> &Endpoints {
-        &self.storage.endpoints()
+        self.storage.endpoints()
     }
 
     /// Returns the product configuration, or an error on error. The result may be cached.

--- a/src/impl/geoip.rs
+++ b/src/impl/geoip.rs
@@ -1,4 +1,4 @@
-use crate::r#impl::config::{Endpoint, Endpoints};
+use crate::r#impl::config::Endpoint;
 use async_compat::Compat;
 use geoutils::{Distance, Location};
 use itertools::Itertools;
@@ -7,8 +7,42 @@ use maxminddb::geoip2;
 use rocket::futures::executor;
 use std::net::{IpAddr, Ipv4Addr};
 
+pub fn sort_by_location<S: AsRef<[u8]>>(
+    endpoints: &mut [Endpoint],
+    geoipdb: &maxminddb::Reader<S>,
+    ip_addr: IpAddr,
+) {
+    match geoipdb.lookup::<geoip2::City>(ip_addr) {
+        Ok(city) => match city.location {
+            Some(geoip2::city::Location {
+                latitude: Some(lat),
+                longitude: Some(lon),
+                ..
+            }) => endpoints.sort_by_key(|ep| {
+                ep.location
+                    .distance_to(&Location::new(lat, lon))
+                    .unwrap_or_else(|_| Distance::from_meters(9999999))
+                    .meters()
+                    .abs() as i64
+            }),
+            _ => {
+                debug!(
+                    "Failed to find location for IP address: {:?} has no location information.",
+                    city
+                );
+            }
+        },
+        Err(err) => {
+            debug!(
+                "Failed to find location for IP address: {}: {}",
+                ip_addr, err
+            );
+        }
+    }
+}
+
 pub fn find_best_location<'a, S: AsRef<[u8]>>(
-    endpoints: &'a Endpoints,
+    endpoints: &'a [Endpoint],
     geoipdb: &maxminddb::Reader<S>,
     ip_addr: IpAddr,
 ) -> &'a Endpoint {
@@ -19,7 +53,6 @@ pub fn find_best_location<'a, S: AsRef<[u8]>>(
                 longitude: Some(lon),
                 ..
             }) => endpoints
-                .get_all()
                 .iter()
                 .sorted_by_key(|ep| {
                     ep.location
@@ -35,7 +68,7 @@ pub fn find_best_location<'a, S: AsRef<[u8]>>(
                     "Failed to find location for IP address: {:?} has no location information.",
                     city
                 );
-                &endpoints.get_all()[0]
+                &endpoints[0]
             }
         },
         Err(err) => {
@@ -43,7 +76,7 @@ pub fn find_best_location<'a, S: AsRef<[u8]>>(
                 "Failed to find location for IP address: {}: {}",
                 ip_addr, err
             );
-            &endpoints.get_all()[0]
+            &endpoints[0]
         }
     }
 }

--- a/src/impl/storage.rs
+++ b/src/impl/storage.rs
@@ -1,12 +1,19 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::future::Future;
 use std::io;
 use std::sync::Mutex;
 
+use crate::r#impl::artifacttype::ArtifactKey;
+use crate::r#impl::config::{Endpoint, Endpoints};
+use crate::r#impl::nightly::NightlyConfig;
+use crate::r#impl::release_map::ReleaseMap;
 use cached::proc_macro::cached;
+use cached::stores::TimedCache;
 use indexmap::IndexMap;
-use log::{debug, warn};
+use itertools::Itertools;
+use log::{debug, error, warn};
 use regex::Regex;
 #[cfg(feature = "s3_bucket_list")]
 use s3::error::S3Error;
@@ -18,34 +25,29 @@ use serde::Deserialize;
 use serde_yaml::Value;
 use thiserror::Error;
 
-use crate::r#impl::artifacttype::ArtifactKey;
-use crate::r#impl::config::Endpoint;
-use crate::r#impl::nightly::NightlyConfig;
-use crate::r#impl::release_map::ReleaseMap;
-
 pub const PRODUCTS_YML: &str = "products.yml";
 
-/// Struct to interact with an endpoint.
+/// Struct to interact with all endpoints.
 pub struct Storage {
-    endpoint: Endpoint,
+    endpoints: Endpoints,
     bucket_list_error_logged: Mutex<RefCell<bool>>,
 }
 
 impl Storage {
-    pub fn new(endpoint: Endpoint) -> Result<Self, String> {
+    pub fn new(endpoints: Endpoints) -> Result<Self, String> {
         Ok(Self {
-            endpoint,
+            endpoints,
             bucket_list_error_logged: Mutex::new(RefCell::new(false)),
         })
     }
 
-    pub fn endpoint_url(&self) -> &str {
-        &self.endpoint.url
+    pub fn endpoints(&self) -> &Endpoints {
+        &self.endpoints
     }
 
     /// Returns the product configuration, or an error on error. The result may be cached.
     pub async fn get_config(&self) -> Result<ProductsConfig, StorageError> {
-        _impl_get_config(self.endpoint.url.clone()).await
+        _impl_get_config(self.endpoints.get_all()).await
     }
 
     #[cfg(feature = "s3_bucket_list")]
@@ -53,59 +55,96 @@ impl Storage {
     /// The result may be cached. If no listing can be retrieved a warning will be logged on the
     /// first call to this function.
     pub async fn get_bucket_list(&self) -> Option<Vec<ListBucketResult>> {
-        _impl_get_bucket_list(
-            self.endpoint
-                .url
-                .replace("http://", "")
-                .replace("https://", ""),
-        )
-        .await
-        .map_err(|err| {
-            let guard = self.bucket_list_error_logged.lock().unwrap();
-            let mut bucket_list_error_logged = guard.borrow_mut();
-            if !*bucket_list_error_logged {
-                warn!(
-                    "The endpoint '{}' does not provide an S3-compatible bucket listing. \
+        _impl_get_bucket_list(self.endpoints.get_all())
+            .await
+            .map_err(|err| {
+                let guard = self.bucket_list_error_logged.lock().unwrap();
+                let mut bucket_list_error_logged = guard.borrow_mut();
+                if !*bucket_list_error_logged {
+                    warn!(
+                        "The endpoints do not provide an S3-compatible bucket listing. \
                          Some information, like file sizes and modification dates, will not be \
                          available: {}.",
-                    &self.endpoint.url, err
-                );
-                *bucket_list_error_logged = true;
-            }
-            err
-        })
-        .ok()
+                        err
+                    );
+                    *bucket_list_error_logged = true;
+                }
+                err
+            })
+            .ok()
     }
 }
 
-#[cached(time = 900, time_refresh = false, sync_writes = true, result = true)]
-async fn _impl_get_config(endpoint_url: String) -> Result<ProductsConfig, StorageError> {
-    debug!("Loading products.yml for {}", endpoint_url);
-    Ok(serde_yaml::from_str(
-        &reqwest::get(format!("{}/{}", endpoint_url, PRODUCTS_YML))
-            .await?
-            .text()
-            .await?,
-    )?)
+#[cached(
+    ty = "TimedCache<String, ProductsConfig>",
+    create = "{ TimedCache::with_lifespan_and_refresh(900, false) }",
+    sync_writes = true,
+    result = true,
+    convert = r##"{ endpoints.iter().map(|e| &e.url).join(",") }"##
+)]
+async fn _impl_get_config(endpoints: &[Endpoint]) -> Result<ProductsConfig, StorageError> {
+    try_with_endpoints(endpoints, |endpoint| async move {
+        debug!("Loading products.yml for {}", &endpoint.url);
+        Ok(serde_yaml::from_str(
+            &reqwest::get(format!("{}/{}", &endpoint.url, PRODUCTS_YML))
+                .await?
+                .text()
+                .await?,
+        )?)
+    })
+    .await
 }
 
 #[cfg(feature = "s3_bucket_list")]
-#[cached(time = 900, time_refresh = false, sync_writes = true, result = true)]
+#[cached(
+    ty = "TimedCache<String, Vec<ListBucketResult>>",
+    create = "{ TimedCache::with_lifespan_and_refresh(900, false) }",
+    sync_writes = true,
+    result = true,
+    convert = r##"{ endpoints.iter().map(|e| &e.url).join(",") }"##
+)]
 async fn _impl_get_bucket_list(
-    endpoint_url: String,
+    endpoints: &[Endpoint],
 ) -> Result<Vec<ListBucketResult>, StorageError> {
-    debug!("Loading bucket listing for {}", endpoint_url);
-    let (bucket_name, endpoint) = endpoint_url
-        .split_once('.')
-        .ok_or(StorageError::NoBucketFound)?;
-    let bucket = Bucket::new_public(
-        bucket_name,
-        Region::Custom {
-            region: "n/a".to_string(),
-            endpoint: endpoint.to_string(),
-        },
-    )?;
-    Ok(bucket.list("".to_string(), None).await?)
+    try_with_endpoints(endpoints, |endpoint| async move {
+        let endpoint_url = endpoint.url.replace("http://", "").replace("https://", "");
+        debug!("Loading bucket listing for {}", &endpoint_url);
+        let (bucket_name, endpoint) = &endpoint_url
+            .split_once('.')
+            .ok_or(StorageError::NoBucketFound)?;
+        let bucket = Bucket::new_public(
+            bucket_name,
+            Region::Custom {
+                region: "n/a".to_string(),
+                endpoint: endpoint.to_string(),
+            },
+        )?;
+        Ok(bucket.list("".to_string(), None).await?)
+    })
+    .await
+}
+
+async fn try_with_endpoints<'a, T, F, Fut>(
+    endpoints: &'a [Endpoint],
+    cb: F,
+) -> Result<T, StorageError>
+where
+    F: Fn(&'a Endpoint) -> Fut,
+    Fut: Future<Output = Result<T, StorageError>> + 'a,
+    T: 'static,
+{
+    let mut last_error = None;
+    for endpoint in endpoints {
+        match cb(endpoint).await {
+            Ok(ok) => return Ok(ok),
+            Err(err) => {
+                warn!("failed endpoint request, triyng next if available.");
+                last_error = Some(err);
+            }
+        }
+    }
+    error!("failed endpoint request, no more endpoints.");
+    Err(last_error.unwrap())
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
Yesterday there was a bigger outage. The primary endpoint was offline and Deposit Box previously did not try to fall back to another endpoint. This implements falling back to the other endpoints for metadata (products.yml) and bucket listing.